### PR TITLE
Mergetool availability

### DIFF
--- a/SimpleUYM/MainWindow.xaml
+++ b/SimpleUYM/MainWindow.xaml
@@ -13,7 +13,7 @@
     <TabControl>
 		<TabItem Header="Main">
 			<StackPanel>
-				<Button Content="Mergetool" Command="{Binding MergetoolCommand}"/>
+				<Button Content="Mergetool" Command="{Binding MergetoolCommand}" IsEnabled="{Binding IsMergetoolAvailable}"/>
 			</StackPanel>
 		</TabItem>
 		<TabItem Header="Config">

--- a/SimpleUYM/ViewModel/MainVM.cs
+++ b/SimpleUYM/ViewModel/MainVM.cs
@@ -80,7 +80,6 @@ namespace SimpleUYM.ViewModel
 			OnRepositoryPathUpdate += UpdateIsSetupAvailable;
 			OnRepositoryPathUpdate += UpdateIsMergetoolAvailable;
 			OnUnityYAMLMergePathUpdate += UpdateIsSetupAvailable;
-			OnUnityYAMLMergePathUpdate += UpdateIsMergetoolAvailable;
 			// Force its update
 			UpdateIsSetupAvailable();
 			UpdateIsMergetoolAvailable();
@@ -95,7 +94,27 @@ namespace SimpleUYM.ViewModel
 			}
 		}
 		private void UpdateIsSetupAvailable() => IsSetupAvailable = !string.IsNullOrEmpty(PathToRepository) && !string.IsNullOrEmpty(PathToUnityYAMLMerge);
-		private void UpdateIsMergetoolAvailable() => IsMergetoolAvailable = !string.IsNullOrEmpty(PathToRepository) && !string.IsNullOrEmpty(PathToUnityYAMLMerge);
+		private void UpdateIsMergetoolAvailable()
+		{
+			if (string.IsNullOrEmpty(PathToRepository))
+			{
+				IsMergetoolAvailable = false;
+				return;
+			}
+			string contentToCheck = "[merge]";
+			string filePath = $"{PathToRepository}\\.git\\config";
+			try
+			{
+				string fileContent = File.ReadAllText(filePath);
+
+				IsMergetoolAvailable = fileContent.Contains(contentToCheck);
+
+			}
+			catch
+			{
+				IsMergetoolAvailable = false;
+			}
+		}
 
 		private void SetupRepository()
 		{
@@ -119,6 +138,7 @@ namespace SimpleUYM.ViewModel
 					// Append the content if not present
 					File.AppendAllText(filePath, contentToAdd);
 					System.Windows.MessageBox.Show("Repository is sucessfully setup", "[SimpleUYM] Setup", MessageBoxButton.OK);
+					IsMergetoolAvailable = true;
 				}
 				else
 				{

--- a/SimpleUYM/ViewModel/MainVM.cs
+++ b/SimpleUYM/ViewModel/MainVM.cs
@@ -52,6 +52,16 @@ namespace SimpleUYM.ViewModel
 				OnPropertyChanged(nameof(IsSetupAvailable));
 			}
 		}
+		private bool _isMergetoolAvailable;
+		public bool IsMergetoolAvailable
+		{
+			get => _isMergetoolAvailable;
+			set
+			{
+				_isMergetoolAvailable = value;
+				OnPropertyChanged(nameof(IsMergetoolAvailable));
+			}
+		}
 
 		private string BatFilePath { get => $"{Environment.CurrentDirectory}\\mergetool.bat"; }
 
@@ -68,9 +78,12 @@ namespace SimpleUYM.ViewModel
 			SetupRepositoryCommand = new RelayCommand(SetupRepository);
 
 			OnRepositoryPathUpdate += UpdateIsSetupAvailable;
+			OnRepositoryPathUpdate += UpdateIsMergetoolAvailable;
 			OnUnityYAMLMergePathUpdate += UpdateIsSetupAvailable;
+			OnUnityYAMLMergePathUpdate += UpdateIsMergetoolAvailable;
 			// Force its update
 			UpdateIsSetupAvailable();
+			UpdateIsMergetoolAvailable();
 		}
 		~MainVM()
 		{
@@ -82,6 +95,7 @@ namespace SimpleUYM.ViewModel
 			}
 		}
 		private void UpdateIsSetupAvailable() => IsSetupAvailable = !string.IsNullOrEmpty(PathToRepository) && !string.IsNullOrEmpty(PathToUnityYAMLMerge);
+		private void UpdateIsMergetoolAvailable() => IsMergetoolAvailable = !string.IsNullOrEmpty(PathToRepository) && !string.IsNullOrEmpty(PathToUnityYAMLMerge);
 
 		private void SetupRepository()
 		{


### PR DESCRIPTION
This fixes #3 

Mergetool will only be available if the repository is setup.
At start up (or when the repository path gets updated) it tries to check for `[merge]` in the `.git\config` file. If it is found, we assume mergetool is available.
If the setup happens, the bool will manually be set to true since no file checking needs to happen as we just wrote it into the file.